### PR TITLE
Override default title_postfix with an empty string. Fixes bjornbjorn/SE...

### DIFF
--- a/system/expressionengine/third_party/seo_lite/mod.seo_lite.php
+++ b/system/expressionengine/third_party/seo_lite/mod.seo_lite.php
@@ -228,7 +228,10 @@ class Seo_lite {
 
         if($vars[$this->tag_prefix.'title'] != '')
         {
-            $title_postfix .= str_replace("&nbsp;"," ",$seolite_entry->default_title_postfix);
+          if ( $this->EE->TMPL->fetch_param('title_postfix', FALSE) === FALSE)
+          {
+            $title_postfix = str_replace("&nbsp;"," ",$seolite_entry->default_title_postfix);
+          }
         }
 
         $vars[$this->tag_prefix.'entry_title'] = $vars[$this->tag_prefix.'title'];


### PR DESCRIPTION
I couldn't find another "simple" way to allow for an empty string using the existing get_param() method.

Thanks!
