### PR TITLE
Adding global option to strip out pagination string from canonical URLs.

### DIFF
--- a/system/expressionengine/third_party/seo_lite/language/english/seo_lite_lang.php
+++ b/system/expressionengine/third_party/seo_lite/language/english/seo_lite_lang.php
@@ -16,7 +16,9 @@ $lang['seodescription'] = 'SEO Meta Description';
 $lang['description_instructions'] = 'Write a short sentence or two that sums up the entry (many search engines will display this in the search results)';
 $lang['default_title_postfix'] = 'Default title postfix';
 $lang['default_title_postfix_description'] = "Whatever you specify here will be appended after the {title}, unless overridden by the <em>title_postfix</em> parameter in the tag.";
-
+$lang['include_pagination_in_canonical_description'] = "Include pagination links (i.e. P10) in canonical URL output?";
+$lang['include_pagination_in_canonical_description_y'] = "Yes";
+$lang['include_pagination_in_canonical_description_n'] = "No";
 
 $lang['docs'] = 'Documentation';
 $lang['settings'] = 'Settings';

--- a/system/expressionengine/third_party/seo_lite/language/french/seo_lite_lang.php
+++ b/system/expressionengine/third_party/seo_lite/language/french/seo_lite_lang.php
@@ -16,7 +16,9 @@ $lang['seodescription'] = 'SEO Description';
 $lang['description_instructions'] = 'Renseignez une ou deux courtes phrases qui résument le contenu de la page (la plupart des moteurs de recherche afficheront ceci dans les résultats de recherche)';
 $lang['default_title_postfix'] = 'Séparateur de titre par défaut';
 $lang['default_title_postfix_description'] = "Ce que vous indiquez ici sera ajouté après le tag {title}, à moins que cette configuration ne soit écrasée par le paramètre <em>title_postfix</em> dans le tag.";
-
+$lang['include_pagination_in_canonical_description'] = "Include pagination links (i.e. P10) in canonical URL output?";
+$lang['include_pagination_in_canonical_description_y'] = "Oui";
+$lang['include_pagination_in_canonical_description_n'] = "Non";
 
 $lang['docs'] = 'Documentation';
 $lang['settings'] = 'Options';

--- a/system/expressionengine/third_party/seo_lite/mcp.seo_lite.php
+++ b/system/expressionengine/third_party/seo_lite/mcp.seo_lite.php
@@ -52,6 +52,7 @@ class Seo_lite_mcp
         $vars['default_description'] = $config->row('default_description');
         $vars['default_keywords'] = $config->row('default_keywords');
         $vars['default_title_postfix'] = $config->row('default_title_postfix');
+        $vars['include_pagination_in_canonical'] = $config->row('include_pagination_in_canonical');
 
 		return $this->content_wrapper('index', 'seo_lite_welcome', $vars);
 	}
@@ -62,6 +63,7 @@ class Seo_lite_mcp
         $default_keywords = $this->EE->input->post('seolite_default_keywords');
         $default_description = $this->EE->input->post('seolite_default_description');
         $default_title_postfix = $this->EE->input->post('seolite_default_title_postfix');
+        $include_pagination_in_canonical = $this->EE->input->post('seolite_include_pagination_in_canonical');
 
         $site_id = $this->EE->config->item('site_id');
         $config = $this->EE->db->get_where('seolite_config', array('site_id' => $site_id));
@@ -71,6 +73,7 @@ class Seo_lite_mcp
                 'default_keywords' => $default_keywords,
                 'default_description' => $default_description,
                 'default_title_postfix' => $default_title_postfix,
+                'include_pagination_in_canonical' => $include_pagination_in_canonical,
             );
 
         if($config->num_rows() == 0)

--- a/system/expressionengine/third_party/seo_lite/mod.seo_lite.php
+++ b/system/expressionengine/third_party/seo_lite/mod.seo_lite.php
@@ -408,6 +408,12 @@ class Seo_lite {
 
     private function get_canonical_url($ignore_last_segments, $page_uri = FALSE)
     {
+        // Check if we're wanting to strip out the pagination segment from the URL
+        $site_id = $this->get_param('site_id', $this->EE->config->item('site_id'));
+        $q = $this->EE->db->get_where('seolite_config', array('seolite_config.site_id' => $site_id));
+        $seolite_entry = $q->row();
+        $include_pagination_in_canonical = $seolite_entry->include_pagination_in_canonical;
+        
         if(!$ignore_last_segments)
         {
             $segments = explode('/', $this->get_request_uri());
@@ -445,7 +451,11 @@ class Seo_lite {
             {
                 $canonical_url = $this->EE->functions->fetch_current_uri();
             }
-
+            
+            if ($include_pagination_in_canonical == "n") {
+                $canonical_url = preg_replace("/P(\d+)$/", "", $canonical_url);
+            }
+            
             return $canonical_url;
         }
         else
@@ -460,7 +470,11 @@ class Seo_lite {
 
             $canonical_url = $this->EE->functions->create_url($canonical_url_segments);
         }
-
+        
+        if ($include_pagination_in_canonical == "n") {
+            $canonical_url = preg_replace("/P(\d+)$/", "", $canonical_url);
+        }
+        
         return $canonical_url;
     }
 

--- a/system/expressionengine/third_party/seo_lite/upd.seo_lite.php
+++ b/system/expressionengine/third_party/seo_lite/upd.seo_lite.php
@@ -13,7 +13,7 @@
  */
 class Seo_lite_upd {
 		
-	var $version        = '1.4.8';
+	var $version        = '1.4.9';
 	var $module_name = "Seo_lite";
 
     /**
@@ -106,6 +106,11 @@ class Seo_lite_upd {
                 'type' => 'varchar',
                 'constraint' => '60',
                 'null' => FALSE),
+            
+            'include_pagination_in_canonical' => array(
+                'type' => 'ENUM("y","n")',
+                'default' => "y",
+                'null' => FALSE),
 
         );
 
@@ -120,6 +125,7 @@ class Seo_lite_upd {
             'default_keywords' => 'your, default, keywords, here',
             'default_description' => 'Your default description here',
             'default_title_postfix' => ' |&nbsp;',
+            'include_pagination_in_canonical' => 'y',
         ));
 
         $this->EE->load->library('layout');

--- a/system/expressionengine/third_party/seo_lite/views/index.php
+++ b/system/expressionengine/third_party/seo_lite/views/index.php
@@ -87,7 +87,18 @@
             form_input('seolite_default_title_postfix', set_value('seolite_default_title_postfix', $default_title_postfix), 'id="seolite_default_title_postfix"')
             )
         );
-
+        
+        $this->table->add_row(array(
+                lang('include_pagination_in_canonical_description', 'seolite_include_pagination_in_canonical'),
+                form_error('seolite_include_pagination_in_canonical').            
+                form_radio('seolite_include_pagination_in_canonical', set_value('seolite_include_pagination_in_canonical', $include_pagination_in_canonical), 'id="seolite_include_pagination_in_canonical_y"')." ".
+                lang('include_pagination_in_canonical_description_y', 'seolite_include_pagination_in_canonical_y').
+                "<br />".
+                form_radio('seolite_include_pagination_in_canonical', set_value('seolite_include_pagination_in_canonical', $include_pagination_in_canonical), 'id="seolite_include_pagination_in_canonical_n"')." ".
+                lang('include_pagination_in_canonical_description_n', 'seolite_include_pagination_in_canonical_n')
+            )
+        );
+        
 		echo $this->table->generate();
 	?>
 	<p>


### PR DESCRIPTION
Hi Bjorn,
I know we're discussing this in another issue, but I had some spare time tonight and thought you might appreciate the help :)

I've just added in a global option for stripping out the pagination strings from the canonical URLs. You can see what I've done here. Pretty basic stuff.

I've tested this out in EE 2.8.1 and it works fine. A URL i.e. "/about-us/media/P10" results in a canonical URL of "/about-us/media/" if "Include pagination links (i.e. P10) in canonical URL output?" is set to "No".

The only thing I'm missing is a french translation for the main control panel label I don't speak French :(

Thanks again for the plugin Bjorn.
